### PR TITLE
Pass Event id as Number instead of String

### DIFF
--- a/src/views/EventDetails.vue
+++ b/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 export default {
   props: ['id'],
   created() {
-    this.$store.dispatch('fetchEvent', this.id).catch(error => {
+    this.$store.dispatch('fetchEvent', Number(this.id)).catch(error => {
       this.$router.push({
         name: 'ErrorDisplay',
         params: { error: error }


### PR DESCRIPTION
Seems that router-link always converts the Id to a string. Thus passing it forward to fetchEvent in store will lead to always loading the Event from EventService instead of reusing 'existingEvent'. Actually this bug this has no effect on the UI since loading the Event will always return the same result.