### PR TITLE
Broken Display of Event Details

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,7 +1,7 @@
 {
   "events": [
     {
-      "id": 123,
+      "id": "8a6b2b12-f958-421e-b8bf-ed3d51ad7909",
       "category": "animal welfare",
       "title": "Cat Adoption Day",
       "description": "Find your new feline friend at this event.",
@@ -11,7 +11,7 @@
       "organizer": "Kat Laydee"
     },
     {
-      "id": 456,
+      "id": "17b8856d-057f-4234-bf8f-fcf7eb569555",
       "category": "food",
       "title": "Community Gardening",
       "description": "Join us as we tend to the community edible plants.",
@@ -21,7 +21,7 @@
       "organizer": "Fern Pollin"
     },
     {
-      "id": 789,
+      "id": "4d03c7b6-b235-4382-a473-0cca0516b66c",
       "category": "sustainability",
       "title": "Beach Cleanup",
       "description": "Help pick up trash along the shore.",

--- a/src/views/EventDetails.vue
+++ b/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 export default {
   props: ['id'],
   created() {
-    this.$store.dispatch('fetchEvent', this.id).catch(error => {
+    this.$store.dispatch('fetchEvent', Number(this.id)).catch(error => {
       this.$router.push({
         name: 'ErrorDisplay',
         params: { error: error }

--- a/src/views/EventDetails.vue
+++ b/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 export default {
   props: ['id'],
   created() {
-    this.$store.dispatch('fetchEvent', Number(this.id)).catch(error => {
+    this.$store.dispatch('fetchEvent', this.id).catch(error => {
       this.$router.push({
         name: 'ErrorDisplay',
         params: { error: error }


### PR DESCRIPTION
After changing the data type from string to number newly created events lead to GET /events/NaN resulting in 404 at the json-server.
This is because events are created with a UUID as id which is a string.
So the actual problem is that the predefined event data contains numbers as ids while the created events get strings.
This patch reverts my last pull request and fixes the predefined data instead.